### PR TITLE
Fix .d.ts export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,2 @@
-export default function isElectron(): boolean;
+function isElectron (): boolean
+export = isElectron


### PR DESCRIPTION
This modules uses commonjs default exports, so theres not actually a `default` named export.