### PR TITLE
fix for broken typings issue

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
-function isElectron (): boolean
+declare function isElectron (): boolean
 export = isElectron


### PR DESCRIPTION
# Pull request questions

## Which issue does this address
Top-level declarations require `declare` or `export` modifier
resolves #9

## Why was change needed
When compiling projects using `typescript@4.5.4` that include the `is-electron@2.2.1` library, the compiler throws:
```
node_modules/is-electron/index.d.ts:1:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

1 function isElectron (): boolean
```  

## What does change improve
projects including this library continue to compile  :-)