### PR TITLE
Fix types in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
-function isElectron (): boolean
+declare function isElectron (): boolean
 export = isElectron


### PR DESCRIPTION
# Description

The current index.d.ts triggers an error:

```
../../node_modules/is-electron/index.d.ts:1:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

1 function isElectron (): boolean
  ~~~~~~~~
```

In this PR, we fix this error.